### PR TITLE
Use / instead of . in API's URL

### DIFF
--- a/sos21-api-server/src/handler.rs
+++ b/sos21-api-server/src/handler.rs
@@ -112,7 +112,7 @@ macro_rules! handler {
         $($param:ident : $ty:ty),* $(,)?
     ) -> HandlerResult<$resp:ty, $err:ty> $body:block) => {
         $vis async fn $name(
-            $(, $param: $ty)*
+            $($param: $ty),*
         ) -> Result<impl ::warp::reply::Reply, ::warp::reject::Rejection> {
             let result: HandlerResult<$resp, $err> = $body;
             crate::handler::handle_handler_result(result)

--- a/sos21-api-server/src/handler/health/liveness.rs
+++ b/sos21-api-server/src/handler/health/liveness.rs
@@ -1,7 +1,10 @@
 use crate::handler::{HandlerResponse, HandlerResult};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use warp::http::StatusCode;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Response {
@@ -25,6 +28,6 @@ impl HandlerResponse for Response {
 }
 
 #[apply_macro::apply(handler)]
-pub async fn handler() -> HandlerResult<Response, Error> {
+pub async fn handler(_request: Request) -> HandlerResult<Response, Error> {
     Ok(Response { ok: true })
 }

--- a/sos21-api-server/src/handler/me.rs
+++ b/sos21-api-server/src/handler/me.rs
@@ -4,12 +4,15 @@ use crate::app::Context;
 use crate::handler::model::user::User;
 use crate::handler::{HandlerResponse, HandlerResult};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sos21_domain::context::Login;
 use sos21_use_case::get_login_user;
 use warp::http::StatusCode;
 
 pub mod project;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Response {
@@ -39,7 +42,7 @@ impl From<Infallible> for Error {
 }
 
 #[apply_macro::apply(handler)]
-pub async fn handler(ctx: Login<Context>) -> HandlerResult<Response, Error> {
+pub async fn handler(ctx: Login<Context>, _request: Request) -> HandlerResult<Response, Error> {
     let user = get_login_user::run(&ctx).await?;
     let user = User::from_use_case(user);
     Ok(Response { user })


### PR DESCRIPTION
- RPC風だよって風を強く出すために `project.form.list` みたいに `.` で区切っていたが、なんか数が増えてくるとスタックオーバーフローで死ぬようになったので（何？）、 `/` で区切る（= `Filter::and` でつなぐ）
- ルートを書くのがしんどくなってきたので DSL を導入
- パスの終端をチェック（ `health/liveness/aaa` に 404 が帰るようになった）