### PR TITLE
sohosai.comアドレスからの登録を認めるように変更

### DIFF
--- a/sos21-domain/src/model/user/email.rs
+++ b/sos21-domain/src/model/user/email.rs
@@ -50,7 +50,7 @@ impl UserEmailAddress {
         let email = EmailAddress::from_string(s.into()).map_err(|err| EmailAddressError {
             inner: EmailAddressErrorInner::InvalidEmailAddress(err),
         })?;
-        if email.ends_with("tsukuba.ac.jp") {
+        if email.ends_with("tsukuba.ac.jp") || email.ends_with("sohosai.com") {
             Ok(UserEmailAddress(email))
         } else {
             Err(EmailAddressError {
@@ -78,6 +78,7 @@ mod tests {
         assert!(UserEmailAddress::from_string("a.b.c@de.fg").is_err());
         assert!(UserEmailAddress::from_string("ab.c@d-e.fg").is_err());
         assert!(UserEmailAddress::from_string("a@s.tsukuba.ac.jp.com").is_err());
+        assert!(UserEmailAddress::from_string("b@sohosai.com.jp").is_err());
     }
 
     #[test]
@@ -87,5 +88,7 @@ mod tests {
         assert!(UserEmailAddress::from_string("a-c@s.tsukuba.ac.jp").is_ok());
         assert!(UserEmailAddress::from_string("abcde@su.tsukuba.ac.jp").is_ok());
         assert!(UserEmailAddress::from_string("ab.c@coins.tsukuba.ac.jp").is_ok());
+        assert!(UserEmailAddress::from_string("a@external.sohosai.com").is_ok());
+        assert!(UserEmailAddress::from_string("a-b@sohosai.com").is_ok());
     }
 }


### PR DESCRIPTION
`*@external.sohosai.com`を利用した登録を認めるために、`sohosai.com` アドレスからのアカウント作成を認める

来年以降、実委人が `*@sohosai.com` からログインできるようにしたいとも
